### PR TITLE
Fixed rates to Common Format

### DIFF
--- a/services/rates.go
+++ b/services/rates.go
@@ -109,7 +109,7 @@ func (rs *RateSevice) GetCoinToCoinRates(coinFrom *coins.Coin, coinTo *coins.Coi
 		coinRates, err := rs.GetCoinRates(coinTo, true)
 		for _, rate := range coinRates {
 			if rate.Code == "BTC" {
-				return rate.Rate, err
+				return 1 / rate.Rate, err
 			}
 		}
 	}
@@ -117,14 +117,14 @@ func (rs *RateSevice) GetCoinToCoinRates(coinFrom *coins.Coin, coinTo *coins.Coi
 		coinRates, err := rs.GetCoinRates(coinFrom, false)
 		for _, rate := range coinRates {
 			if rate.Code == "BTC" {
-				return 1 / rate.Rate, err
+				return rate.Rate, err
 			}
 		}
 	}
 	if coinFrom.Tag == coinTo.Tag {
 		return rate, config.ErrorNoC2CWithSameCoin
 	}
-	coinFromRates, err := rs.GetCoinRates(coinFrom, false)
+	coinFromRates, err := rs.GetCoinRates(coinFrom, true)
 	coinToRates, err := rs.GetCoinRates(coinTo, false)
 	var coinFromCommonRate float64
 	var coinToCommonRate float64
@@ -138,7 +138,7 @@ func (rs *RateSevice) GetCoinToCoinRates(coinFrom *coins.Coin, coinTo *coins.Coi
 			coinToCommonRate = rate.Rate
 		}
 	}
-	return coinToCommonRate / coinFromCommonRate, err
+	return coinFromCommonRate/coinToCommonRate, err
 }
 
 // GetCoinToCoinRatesWithAmount is used to get the rates from crypto to crypto using a specified amount to convert
@@ -148,7 +148,7 @@ func (rs *RateSevice) GetCoinToCoinRatesWithAmount(coinFrom *coins.Coin, coinTo 
 	}
 	var coinMarkets map[string][]models.MarketOrder
 	var coinRates []models.Rate
-	// First get the orders wall from the coin we are converting
+	// First get the orders wall from the coin we are converting to
 	if coinFrom.Tag == "BTC" {
 		coinMarkets, err = rs.GetCoinOrdersWall(coinTo)
 		if err != nil {


### PR DESCRIPTION
# IMPORTANT!
Don't merge with master until all services have been updated to follow the spec described in change 1

# Description
1. Hans-requested and well needed change in the structure of coin rates for Obol. Rates now use the global format described below, which is used my most places.

_**fromCoin**_ to _**toCoin**_ is read as
**_1 fromCoin_** is Equal to x **_toCoins_**

2. Also added merchant protection by changing the way coin to coin rate is calculated when BTC is not involved. By adding buy side to **_fromCoin_** rates to guarantee selling price of **_fromCoin_**

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added unit tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.